### PR TITLE
Filter out archived repos

### DIFF
--- a/github.sh
+++ b/github.sh
@@ -8,5 +8,5 @@ fi
 
 organization=$1
 
-# JQ
-gh api --paginate "orgs/$organization/repos" | jq -r 'first(["cloneUrl","branch","org"]), (.[] | [.clone_url, .default_branch, "'"$organization"'"]) | @csv'
+echo "\"cloneUrl\",\"branch\",\"org\""
+gh api --paginate "orgs/$organization/repos" --jq '[.[] | select(.archived == false)]' | jq -r '.[] | [.clone_url, .default_branch, "'"$organization"'"] | @csv' | sort

--- a/github.sh
+++ b/github.sh
@@ -9,4 +9,4 @@ fi
 organization=$1
 
 echo "\"cloneUrl\",\"branch\",\"org\""
-gh api --paginate "orgs/$organization/repos" --jq '[.[] | select(.archived == false)]' | jq -r '.[] | [.clone_url, .default_branch, "'"$organization"'"] | @csv' | sort
+gh api --paginate "orgs/$organization/repos" --jq '.[] | select(.archived == false) | [.clone_url, .default_branch, "'"$organization"'"] | @csv' | sort

--- a/github.sh
+++ b/github.sh
@@ -10,3 +10,4 @@ organization=$1
 
 echo "\"cloneUrl\",\"branch\",\"org\""
 gh api --paginate "orgs/$organization/repos" --jq '.[] | select(.archived == false) | [.clone_url, .default_branch, "'"$organization"'"] | @csv' | sort
+#gh api --paginate "orgs/$organization/repos" --jq '.[] | select(.archived == false) | [.ssh_url, .default_branch, "'"$organization"'"] | @csv' | sort


### PR DESCRIPTION
**What**:
Minor improvement for the Github fetching script.
Filtering out archived projects.

Also adding sorting of the output for human readability.

**Why**:
Quite reasonably the customers tend not to want them ingested at all.

