### PR TITLE
Add PowerShell scripts for Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ https://github.com/openrewrite/rewrite-gradle-tooling-model,main
 https://github.com/openrewrite/rewrite-recipe-bom,main
 ```
 
+## Platform Support
+
+Each SCM has two script versions:
+- **Bash scripts** (`.sh`) for Linux and macOS - require `jq` for JSON parsing
+- **PowerShell scripts** (`.ps1`) for Windows - use native PowerShell JSON parsing
+
 ## Supported SCMs
 * [GitHub](#github)
 * [Bitbucket Data Center](#bitbucket-data-center)
 * [Bitbucket Cloud](#bitbucket-cloud)
 * [GitLab](#gitlab)
+* [Azure DevOps](#azure-devops)
 
 Below are the details of each script along with examples of how to invoke them and their required/optional arguments.
 
@@ -45,9 +52,15 @@ This script fetches all repositories from the specified GitHub organization.
 (**Note**: if you use a GitHub installation rather than `github.com` you will have to `gh auth login --hostname github.mycompany.com`)
 
 #### Example
-To fetch all repositories from a GitHub organization:
+
+**Linux/macOS (Bash):**
 ```sh
 ./github.sh my-organization
+```
+
+**Windows (PowerShell):**
+```powershell
+.\github.ps1 -Organization my-organization
 ```
 
 
@@ -64,9 +77,16 @@ This script fetches all repositories from a Bitbucket Data Center instance.
 This script fetches all repositories from the specified Bitbucket Data Center URL. If the `AUTH_TOKEN` environment variable is set, it will be used for authentication.
 
 #### Example
-To fetch all repositories from a Bitbucket Data Center instance:
+
+**Linux/macOS (Bash):**
 ```sh
 AUTH_TOKEN=YOUR_TOKEN ./bitbucket-data-center.sh https://my-bitbucket.com/stash
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:AUTH_TOKEN = "YOUR_TOKEN"
+.\bitbucket-data-center.ps1 -BitbucketUrl https://my-bitbucket.com/stash
 ```
 
 #### Optional Environment Variables
@@ -85,9 +105,19 @@ This script fetches all repositories from a Bitbucket Cloud workspace.
 This script fetches all repositories from the specified Bitbucket Cloud workspace. Authentication is provided via the `-u` (username) and `-p` (app password) options, or via the `BITBUCKET_USERNAME` and `BITBUCKET_APP_PASSWORD` environment variables.
 
 #### Example
-To fetch all repositories from a Bitbucket Cloud workspace:
+
+**Linux/macOS (Bash):**
 ```sh
 ./bitbucket-cloud.sh -u YOUR_USERNAME -p APP_PASSWORD myworkspace
+```
+
+**Windows (PowerShell):**
+```powershell
+.\bitbucket-cloud.ps1 -Workspace myworkspace -Username YOUR_USERNAME -AppPassword APP_PASSWORD
+# Or using environment variables:
+$env:BITBUCKET_USERNAME = "YOUR_USERNAME"
+$env:BITBUCKET_APP_PASSWORD = "APP_PASSWORD"
+.\bitbucket-cloud.ps1 -Workspace myworkspace
 ```
 
 #### Optional Environment Variables
@@ -106,9 +136,18 @@ This script fetches all repositories from a GitLab instance or a specific group 
 This script fetches all repositories from a GitLab instance or a specific group within a GitLab instance. The `AUTH_TOKEN` environment variable must be set for authentication. The `-g` option specifies a group to fetch repositories from. The `-h` option specifies the GitLab domain (defaults to `https://gitlab.com` if not provided).
 
 #### Example
-To fetch all repositories from a specific group on a custom GitLab domain:
+
+**Linux/macOS (Bash):**
 ```sh
 AUTH_TOKEN=YOUR_TOKEN ./gitlab.sh -g my-group -h https://my-gitlab.com
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:AUTH_TOKEN = "YOUR_TOKEN"
+.\gitlab.ps1 -Group my-group -GitLabDomain https://my-gitlab.com
+# Without group (all user's projects):
+.\gitlab.ps1
 ```
 
 #### Optional Environment Variables
@@ -135,8 +174,18 @@ One Organization has multiple Projects, which each can contain multiple Reposito
 3. Azure CLI must be logged in `az login` and user has access to the organization and project
 
 #### Example
-To fetch all repositories from an Azure DevOps organization and project:
+
+**Linux/macOS (Bash):**
 ```sh
 ./azure-devops.sh -o <organization> -p <project>
+# Use -h flag for HTTPS URLs instead of SSH
+./azure-devops.sh -o <organization> -p <project> -h
+```
+
+**Windows (PowerShell):**
+```powershell
+.\azure-devops.ps1 -Organization <organization> -Project <project>
+# Use -UseHttps switch for HTTPS URLs instead of SSH
+.\azure-devops.ps1 -Organization <organization> -Project <project> -UseHttps
 ```
 

--- a/azure-devops.ps1
+++ b/azure-devops.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Fetches repository information from Azure DevOps.
+
+.DESCRIPTION
+    Queries the Azure DevOps API for all repositories in a project
+    and outputs CSV data with clone URLs and default branches.
+
+.PARAMETER Organization
+    The Azure DevOps organization name
+
+.PARAMETER Project
+    The Azure DevOps project name
+
+.PARAMETER UseHttps
+    Use HTTPS URLs instead of SSH URLs (default is SSH)
+
+.EXAMPLE
+    .\azure-devops.ps1 -Organization myorg -Project myproject
+    .\azure-devops.ps1 -Organization myorg -Project myproject -UseHttps
+
+.NOTES
+    Requires Azure CLI (az) to be installed and authenticated.
+    Run 'az login' and 'az extension add --name azure-devops' before using this script.
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Organization,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Project,
+
+    [switch]$UseHttps
+)
+
+# Output CSV header
+Write-Output "cloneUrl,branch"
+
+# Fetch repositories using Azure CLI
+$repos = az repos list --organization "https://dev.azure.com/$Organization" --project $Project --output json | ConvertFrom-Json
+
+foreach ($repo in $repos) {
+    # Select URL based on protocol preference
+    if ($UseHttps) {
+        $cloneUrl = $repo.remoteUrl
+    } else {
+        $cloneUrl = $repo.sshUrl
+    }
+
+    # Handle defaultBranch - might be empty, null, or have refs/heads/ prefix
+    $branch = $repo.defaultBranch
+    if ([string]::IsNullOrEmpty($branch) -or $branch -eq "null") {
+        $branch = "main"
+    } else {
+        # Remove refs/heads/ prefix if present
+        $branch = $branch -replace '^refs/heads/', ''
+    }
+
+    # Output as CSV row
+    Write-Output ('"{0}","{1}"' -f $cloneUrl, $branch)
+}

--- a/bitbucket-cloud.ps1
+++ b/bitbucket-cloud.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Fetches repository information from Bitbucket Cloud.
+
+.DESCRIPTION
+    Queries the Bitbucket Cloud API for all repositories in a workspace
+    and outputs CSV data with clone URLs and default branches.
+
+.PARAMETER Workspace
+    The Bitbucket Cloud workspace name (required)
+
+.PARAMETER Username
+    Bitbucket username. Can also be set via BITBUCKET_USERNAME environment variable.
+
+.PARAMETER AppPassword
+    Bitbucket app password. Can also be set via BITBUCKET_APP_PASSWORD environment variable.
+
+.EXAMPLE
+    .\bitbucket-cloud.ps1 -Workspace myworkspace -Username myuser -AppPassword mypassword
+    $env:BITBUCKET_USERNAME = "myuser"
+    $env:BITBUCKET_APP_PASSWORD = "mypassword"
+    .\bitbucket-cloud.ps1 -Workspace myworkspace
+
+.NOTES
+    Requires Bitbucket app password (not regular password).
+    Optionally set CLONE_PROTOCOL environment variable to "ssh" for SSH URLs (default is https).
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$Workspace,
+
+    [Parameter(Mandatory=$false)]
+    [string]$Username,
+
+    [Parameter(Mandatory=$false)]
+    [string]$AppPassword
+)
+
+# Fall back to environment variables if not provided
+if ([string]::IsNullOrEmpty($Username)) {
+    $Username = $env:BITBUCKET_USERNAME
+}
+
+if ([string]::IsNullOrEmpty($AppPassword)) {
+    $AppPassword = $env:BITBUCKET_APP_PASSWORD
+}
+
+# Validate required parameters
+if ([string]::IsNullOrEmpty($Username) -or [string]::IsNullOrEmpty($AppPassword)) {
+    Write-Error "Error: Please provide username and app password via parameters or environment variables."
+    Write-Host "Usage: .\bitbucket-cloud.ps1 -Workspace <workspace> -Username <username> -AppPassword <password>"
+    exit 1
+}
+
+# Determine clone protocol
+$cloneProtocol = if ($env:CLONE_PROTOCOL -eq "ssh") { "ssh" } else { "https" }
+
+# Set up Basic auth header
+$base64Auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${Username}:${AppPassword}"))
+$headers = @{
+    Authorization = "Basic $base64Auth"
+}
+
+# Output CSV header
+Write-Output "cloneUrl,branch"
+
+$nextPage = "https://api.bitbucket.org/2.0/repositories/$Workspace"
+
+while (-not [string]::IsNullOrEmpty($nextPage)) {
+    try {
+        $response = Invoke-RestMethod -Uri $nextPage -Headers $headers -ErrorAction Stop
+    } catch {
+        Write-Error "Error from Bitbucket API: $($_.Exception.Message)"
+        exit 1
+    }
+
+    # Process each repository
+    foreach ($repo in $response.values) {
+        # Find clone URL by protocol
+        $cloneUrl = ($repo.links.clone | Where-Object { $_.name -eq $cloneProtocol }).href
+
+        # Get main branch name
+        $branchName = $repo.mainbranch.name
+
+        # Clean credentials from URL (remove username@ from https://username@bitbucket.org/...)
+        $cleanUrl = $cloneUrl -replace 'https://[^@]+@', 'https://'
+
+        # Output as CSV row
+        Write-Output "$cleanUrl,$branchName"
+    }
+
+    # Get next page URL (remove embedded credentials)
+    $nextPage = $response.next
+    if (-not [string]::IsNullOrEmpty($nextPage)) {
+        $nextPage = $nextPage -replace "${Username}@", ''
+    }
+}

--- a/bitbucket-data-center.ps1
+++ b/bitbucket-data-center.ps1
@@ -1,0 +1,123 @@
+<#
+.SYNOPSIS
+    Fetches repository information from Bitbucket Data Center.
+
+.DESCRIPTION
+    Queries the Bitbucket Data Center API for all repositories
+    and outputs CSV data with clone URLs and default branches.
+
+.PARAMETER BitbucketUrl
+    The base URL of the Bitbucket Data Center instance (e.g., https://my-bitbucket.com/stash)
+
+.EXAMPLE
+    $env:AUTH_TOKEN = "your-token"
+    .\bitbucket-data-center.ps1 -BitbucketUrl https://my-bitbucket.com/stash
+
+.NOTES
+    Requires AUTH_TOKEN environment variable to be set with a Bitbucket personal access token.
+    Optionally set CLONE_PROTOCOL environment variable to "ssh" for SSH URLs (default is http).
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$BitbucketUrl
+)
+
+# Validate AUTH_TOKEN
+if ([string]::IsNullOrEmpty($env:AUTH_TOKEN)) {
+    Write-Error "Please set the AUTH_TOKEN environment variable."
+    exit 1
+}
+
+# Determine clone protocol
+$cloneProtocol = if ($env:CLONE_PROTOCOL -eq "ssh") { "ssh" } else { "http" }
+
+# Set up headers
+$headers = @{
+    "Content-Type" = "application/json"
+    Authorization = "Bearer $env:AUTH_TOKEN"
+}
+
+function Get-DefaultBranch {
+    param(
+        [string]$RepoSlug,
+        [string]$Project
+    )
+
+    $nextPage = 0
+    $lastPage = $false
+    $firstBranch = $null
+
+    while (-not $lastPage) {
+        $requestUrl = "$BitbucketUrl/rest/api/1.0/projects/$Project/repos/$RepoSlug/branches?start=$nextPage&limit=100"
+
+        try {
+            $response = Invoke-RestMethod -Uri $requestUrl -Headers $headers -ErrorAction Stop
+        } catch {
+            Write-Warning "Error occurred while fetching default branch for $RepoSlug`: $($_.Exception.Message)"
+            return ""
+        }
+
+        $lastPage = $response.isLastPage
+        $nextPage = $response.nextPageStart
+
+        foreach ($branch in $response.values) {
+            # Store first branch as fallback
+            if ($null -eq $firstBranch) {
+                $firstBranch = $branch.displayId
+            }
+
+            if ($branch.isDefault -eq $true) {
+                return $branch.displayId
+            }
+        }
+    }
+
+    # If no default branch was found but we have branches, use the first one
+    if (-not [string]::IsNullOrEmpty($firstBranch)) {
+        Write-Warning "No default branch found for $RepoSlug, using first branch: $firstBranch"
+        return $firstBranch
+    } else {
+        Write-Warning "Failed to find any branches for $RepoSlug."
+        return ""
+    }
+}
+
+function Get-Repositories {
+    $nextPage = 0
+    $lastPage = $false
+
+    while (-not $lastPage) {
+        $requestUrl = "$BitbucketUrl/rest/api/1.0/repos?start=$nextPage&limit=100"
+
+        try {
+            $response = Invoke-RestMethod -Uri $requestUrl -Headers $headers -ErrorAction Stop
+        } catch {
+            Write-Error "Error occurred while retrieving repository list: $($_.Exception.Message)"
+            exit 1
+        }
+
+        $lastPage = $response.isLastPage
+        $nextPage = $response.nextPageStart
+
+        foreach ($repo in $response.values) {
+            # Find clone URL by protocol
+            $cloneUrl = ($repo.links.clone | Where-Object { $_.name -eq $cloneProtocol }).href
+
+            $repoSlug = $repo.slug
+            $project = $repo.project.key
+
+            # Fetch default branch for this repo
+            $defaultBranch = Get-DefaultBranch -RepoSlug $repoSlug -Project $project
+
+            # Output as CSV row
+            Write-Output "$cloneUrl,$defaultBranch"
+        }
+    }
+}
+
+# Output CSV header
+Write-Output "cloneUrl,branch"
+
+# Fetch all repositories
+Get-Repositories

--- a/github.ps1
+++ b/github.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Fetches repository information from a GitHub organization.
+
+.DESCRIPTION
+    Queries the GitHub API for all non-archived repositories in an organization
+    and outputs CSV data with clone URLs, branches, and metadata.
+
+.PARAMETER Organization
+    The GitHub organization name (e.g., "openrewrite")
+
+.EXAMPLE
+    .\github.ps1 -Organization openrewrite
+    .\github.ps1 openrewrite
+
+.NOTES
+    Requires GitHub CLI (gh) to be installed and authenticated.
+    Run 'gh auth login' before using this script.
+#>
+
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$Organization
+)
+
+# Output CSV header
+Write-Output '"cloneUrl","branch","origin","path","org"'
+
+# Fetch repositories using GitHub CLI with pagination
+$repos = gh api --paginate "orgs/$Organization/repos" | ConvertFrom-Json
+
+# Filter non-archived repos, extract fields, and output CSV
+$repos | Where-Object { -not $_.archived } | ForEach-Object {
+    $cloneUrl = $_.clone_url
+    $branch = $_.default_branch
+
+    # Extract origin (domain) from URL: https://github.com/org/repo -> github.com
+    $origin = $cloneUrl -replace '^https://', '' -replace '/.*$', ''
+
+    # Extract path from URL: https://github.com/org/repo.git -> org/repo
+    $path = $cloneUrl -replace '^https://[^/]+/', '' -replace '\.git$', ''
+
+    # Output as CSV row
+    '"{0}","{1}","{2}","{3}","{4}"' -f $cloneUrl, $branch, $origin, $path, $Organization
+} | Sort-Object

--- a/gitlab.ps1
+++ b/gitlab.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Fetches repository information from GitLab.
+
+.DESCRIPTION
+    Queries the GitLab API for all projects in a group (or all user's projects)
+    and outputs CSV data with clone URLs, branches, and metadata.
+
+.PARAMETER Group
+    Optional GitLab group name. If not specified, returns all user's projects.
+
+.PARAMETER GitLabDomain
+    Optional GitLab domain URL. Defaults to https://gitlab.com
+
+.EXAMPLE
+    $env:AUTH_TOKEN = "your-token"
+    .\gitlab.ps1
+    .\gitlab.ps1 -Group mygroup
+    .\gitlab.ps1 -Group mygroup -GitLabDomain https://gitlab.mycompany.com
+
+.NOTES
+    Requires AUTH_TOKEN environment variable to be set with a GitLab personal access token.
+    Optionally set CLONE_PROTOCOL environment variable to "ssh" for SSH URLs (default is https).
+#>
+
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Group,
+
+    [Parameter(Mandatory=$false)]
+    [string]$GitLabDomain = "https://gitlab.com"
+)
+
+# Validate AUTH_TOKEN
+if ([string]::IsNullOrEmpty($env:AUTH_TOKEN)) {
+    Write-Error "Please set the AUTH_TOKEN environment variable."
+    exit 1
+}
+
+# Determine clone protocol
+$cloneProtocol = if ($env:CLONE_PROTOCOL -eq "ssh") { "ssh" } else { "https" }
+
+# Build base request URL
+if ([string]::IsNullOrEmpty($Group)) {
+    $baseUrl = "$GitLabDomain/api/v4/projects?membership=true&simple=true&archived=false"
+} else {
+    $baseUrl = "$GitLabDomain/api/v4/groups/$Group/projects?include_subgroups=true&simple=true&archived=false"
+}
+
+# Extract origin from domain (remove https:// prefix)
+$origin = $GitLabDomain -replace '^https?://', ''
+
+# Set up headers
+$headers = @{
+    Authorization = "Bearer $env:AUTH_TOKEN"
+}
+
+# Output CSV header
+Write-Output '"cloneUrl","branch","origin","path","org"'
+
+$page = 1
+$perPage = 100
+
+while ($true) {
+    $requestUrl = "$baseUrl&page=$page&per_page=$perPage"
+
+    try {
+        $response = Invoke-RestMethod -Uri $requestUrl -Headers $headers -ErrorAction Stop
+    } catch {
+        Write-Error "Error from GitLab API: $($_.Exception.Message)"
+        exit 1
+    }
+
+    # Check if response is empty (no more results)
+    if ($null -eq $response -or $response.Count -eq 0) {
+        break
+    }
+
+    # Process and output data
+    foreach ($project in $response) {
+        # Select clone URL based on protocol
+        if ($cloneProtocol -eq "ssh") {
+            $cloneUrl = $project.ssh_url_to_repo
+        } else {
+            $cloneUrl = $project.http_url_to_repo
+        }
+
+        $branch = $project.default_branch
+        $path = $project.path_with_namespace
+        $org = $project.namespace.path
+
+        # Output as CSV row
+        Write-Output ('"{0}","{1}","{2}","{3}","{4}"' -f $cloneUrl, $branch, $origin, $path, $org)
+    }
+
+    $page++
+}


### PR DESCRIPTION
## Summary

- Add PowerShell (.ps1) versions of all repository fetcher scripts for Windows users
- Use native PowerShell JSON parsing instead of requiring jq
- Update README with PowerShell examples for each SCM

## Problem

The existing bash scripts require jq for JSON parsing, which is not available by default on Windows. Windows users need to install additional utilities to use these scripts.

## Solution

Created PowerShell equivalents that use native `ConvertFrom-Json` and `Invoke-RestMethod` for JSON handling. This works out of the box on Windows without any additional dependencies.

**New scripts:**
- `github.ps1`
- `azure-devops.ps1`
- `gitlab.ps1`
- `bitbucket-cloud.ps1`
- `bitbucket-data-center.ps1`

## Test plan

- [x] Test each PowerShell script with its respective SCM
- [x] Verify CSV output format matches bash equivalents