### PR TITLE
Add origin and path to PowerShell scripts and fix BBDC path bug

### DIFF
--- a/azure-devops.ps1
+++ b/azure-devops.ps1
@@ -35,10 +35,13 @@ param(
 )
 
 # Output CSV header
-Write-Output "cloneUrl,branch"
+Write-Output "cloneUrl,branch,origin,path"
 
 # Fetch repositories using Azure CLI
 $repos = az repos list --organization "https://dev.azure.com/$Organization" --project $Project --output json | ConvertFrom-Json
+
+# Origin is always dev.azure.com/org for consistency
+$origin = "dev.azure.com/$Organization"
 
 foreach ($repo in $repos) {
     # Select URL based on protocol preference
@@ -57,6 +60,9 @@ foreach ($repo in $repos) {
         $branch = $branch -replace '^refs/heads/', ''
     }
 
+    # Path is project/_git/repo for consistency
+    $path = "$Project/_git/$($repo.name)"
+
     # Output as CSV row
-    Write-Output ('"{0}","{1}"' -f $cloneUrl, $branch)
+    Write-Output ('"{0}","{1}","{2}","{3}"' -f $cloneUrl, $branch, $origin, $path)
 }

--- a/bitbucket-cloud.ps1
+++ b/bitbucket-cloud.ps1
@@ -63,7 +63,7 @@ $headers = @{
 }
 
 # Output CSV header
-Write-Output "cloneUrl,branch"
+Write-Output "cloneUrl,branch,origin,path"
 
 $nextPage = "https://api.bitbucket.org/2.0/repositories/$Workspace"
 
@@ -86,8 +86,20 @@ while (-not [string]::IsNullOrEmpty($nextPage)) {
         # Clean credentials from URL (remove username@ from https://username@bitbucket.org/...)
         $cleanUrl = $cloneUrl -replace 'https://[^@]+@', 'https://'
 
+        # Origin is always bitbucket.org for cloud
+        $origin = "bitbucket.org"
+
+        # Extract path (workspace/repo) from URL
+        if ($cleanUrl -match 'git@') {
+            # SSH: git@bitbucket.org:workspace/repository.git
+            $path = $cleanUrl -replace '^git@[^:]+:', '' -replace '\.git$', ''
+        } else {
+            # HTTPS: https://bitbucket.org/workspace/repository.git
+            $path = $cleanUrl -replace '^https://[^/]+/', '' -replace '\.git$', ''
+        }
+
         # Output as CSV row
-        Write-Output "$cleanUrl,$branchName"
+        Write-Output "$cleanUrl,$branchName,$origin,$path"
     }
 
     # Get next page URL (remove embedded credentials)

--- a/bitbucket-data-center.ps1
+++ b/bitbucket-data-center.ps1
@@ -110,14 +110,20 @@ function Get-Repositories {
             # Fetch default branch for this repo
             $defaultBranch = Get-DefaultBranch -RepoSlug $repoSlug -Project $project
 
+            # Extract path (project/repo)
+            $path = "$project/$repoSlug"
+
             # Output as CSV row
-            Write-Output "$cloneUrl,$defaultBranch"
+            Write-Output "$cloneUrl,$defaultBranch,$origin,$path"
         }
     }
 }
 
+# Extract origin from BitbucketUrl (domain + optional context path like /stash)
+$origin = $BitbucketUrl -replace '^https?://', '' -replace '/scm.*$', '' -replace '/$', ''
+
 # Output CSV header
-Write-Output "cloneUrl,branch"
+Write-Output "cloneUrl,branch,origin,path"
 
 # Fetch all repositories
 Get-Repositories

--- a/bitbucket-data-center.sh
+++ b/bitbucket-data-center.sh
@@ -112,10 +112,16 @@ function fetch_repos() {
                 fi
                 path=$(echo $clone_url | sed -E 's|ssh://[^/]+/||; s|\.git$||')
             else
-                # HTTPS: https://scm.mycompany.com/stash/scm/PROJ/repo.git
-                origin=$(echo $clone_url | sed -E 's|https://([^/]+(/[^/]+)?)/.*|\1|')
+                # HTTPS: https://scm.mycompany.com/stash/scm/PROJ/repo.git or http://localhost:7990/scm/PROJ/repo.git
+                # Extract just the host:port first
+                origin=$(echo $clone_url | sed -E 's|https?://([^/]+)/.*|\1|')
+                # Append context path (like /stash) if bitbucket_url contains it
+                context_path=$(echo "$bitbucket_url" | sed -E 's|https?://[^/]+||; s|/$||')
+                if [[ -n "$context_path" ]]; then
+                    origin="$origin$context_path"
+                fi
                 # Remove /scm from path for HTTPS
-                path=$(echo $clone_url | sed -E 's|https://[^/]+(/[^/]+)?/scm/||; s|https://[^/]+(/[^/]+)?/||; s|\.git$||')
+                path=$(echo $clone_url | sed -E 's|https?://[^/]+(/[^/]+)?/scm/||; s|https?://[^/]+(/[^/]+)?/||; s|\.git$||')
             fi
             echo $clone_url,$default_branch,$origin,$path
         done


### PR DESCRIPTION
## Summary
- Add `origin` and `path` fields to the three PowerShell scripts that were missing them:
  - `azure-devops.ps1`
  - `bitbucket-cloud.ps1`
  - `bitbucket-data-center.ps1`
- Fix `bitbucket-data-center.sh` to correctly handle `http://` URLs and exclude `/scm` from the origin field

## Test plan
- [x] Tested BBDC bash script against local instance - origin is now `localhost:7990` instead of `localhost:7990/scm`
- [x] Verify PowerShell scripts output correct CSV format with origin and path columns