### PR TITLE
Add jq dependency check to GitLab fetcher

### DIFF
--- a/gitlab.ps1
+++ b/gitlab.ps1
@@ -44,7 +44,8 @@ $cloneProtocol = if ($env:CLONE_PROTOCOL -eq "ssh") { "ssh" } else { "https" }
 if ([string]::IsNullOrEmpty($Group)) {
     $baseUrl = "$GitLabDomain/api/v4/projects?membership=true&simple=true&archived=false"
 } else {
-    $baseUrl = "$GitLabDomain/api/v4/groups/$Group/projects?include_subgroups=true&simple=true&archived=false"
+    $encodedGroup = $Group -replace '/', '%2F'
+    $baseUrl = "$GitLabDomain/api/v4/groups/$encodedGroup/projects?include_subgroups=true&simple=true&archived=false"
 }
 
 # Extract origin from domain (remove https:// prefix)

--- a/gitlab.ps1
+++ b/gitlab.ps1
@@ -44,8 +44,7 @@ $cloneProtocol = if ($env:CLONE_PROTOCOL -eq "ssh") { "ssh" } else { "https" }
 if ([string]::IsNullOrEmpty($Group)) {
     $baseUrl = "$GitLabDomain/api/v4/projects?membership=true&simple=true&archived=false"
 } else {
-    $encodedGroup = $Group -replace '/', '%2F'
-    $baseUrl = "$GitLabDomain/api/v4/groups/$encodedGroup/projects?include_subgroups=true&simple=true&archived=false"
+    $baseUrl = "$GitLabDomain/api/v4/groups/$Group/projects?include_subgroups=true&simple=true&archived=false"
 }
 
 # Extract origin from domain (remove https:// prefix)

--- a/gitlab.sh
+++ b/gitlab.sh
@@ -52,7 +52,8 @@ GITLAB_DOMAIN=${GITLAB_DOMAIN:-https://gitlab.com}
 if [[ -z $GROUP ]]; then
     base_request_url="$GITLAB_DOMAIN/api/v4/projects?membership=true&simple=true&archived=false"
 else
-    base_request_url="$GITLAB_DOMAIN/api/v4/groups/$GROUP/projects?include_subgroups=true&simple=true&archived=false"
+    encoded_group="${GROUP//\//%2F}"
+    base_request_url="$GITLAB_DOMAIN/api/v4/groups/$encoded_group/projects?include_subgroups=true&simple=true&archived=false"
 fi
 
 page=1

--- a/gitlab.sh
+++ b/gitlab.sh
@@ -37,6 +37,12 @@ while getopts ":g:h:" opt; do
 done
 
 
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed." >&2
+    echo "Install it from https://jqlang.github.io/jq/download/ or use gitlab.ps1 on Windows." >&2
+    exit 1
+fi
+
 if [[ -z $AUTH_TOKEN ]]; then
     echo "Please set the AUTH_TOKEN environment variable."
     exit 1
@@ -52,8 +58,7 @@ GITLAB_DOMAIN=${GITLAB_DOMAIN:-https://gitlab.com}
 if [[ -z $GROUP ]]; then
     base_request_url="$GITLAB_DOMAIN/api/v4/projects?membership=true&simple=true&archived=false"
 else
-    encoded_group="${GROUP//\//%2F}"
-    base_request_url="$GITLAB_DOMAIN/api/v4/groups/$encoded_group/projects?include_subgroups=true&simple=true&archived=false"
+    base_request_url="$GITLAB_DOMAIN/api/v4/groups/$GROUP/projects?include_subgroups=true&simple=true&archived=false"
 fi
 
 page=1


### PR DESCRIPTION
The GitLab bash script (`gitlab.sh`) uses `jq` for JSON parsing but doesn't check if it's installed. On Windows (MINGW64/Git Bash), where `jq` is typically not available, the script fails with a misleading "Invalid JSON response from GitLab API" error because the `jq` validation check suppresses stderr.

This adds an explicit `jq` dependency check at the top of the script with a clear error message pointing users to either install `jq` or use the PowerShell equivalent (`gitlab.ps1`) on Windows.